### PR TITLE
updated ciwheel builder

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -29,7 +29,7 @@ jobs:
           submodules: recursive
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.23.0
+        uses: pypa/cibuildwheel@v3.2.1
         env:
           CIBW_BUILD: "cp*-${{ matrix.arch }}"
           CIBW_ARCHS_LINUX: "x86_64"


### PR DESCRIPTION
this update to ciwheelbuild means it builds wheels for python 3.14 and 3.14t
resulting artifacts which include thee newer versions of python can be seen here https://github.com/shimwell/moab-python/actions/runs/19137511327

The current main branch of the sigma-toolkit/moab-python does not currently build wheels for python 3.14 as found out today in this action https://github.com/sigma-toolkit/moab-python/actions/runs/19135515414
